### PR TITLE
fix: replace archived useblacksmith actions with official actions (ACC-1172)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
   steps:
     - name: Setup Golang
       if: ${{ inputs.go == 'true' || inputs.enable-all == 'true'}}
-      uses: useblacksmith/setup-go@v6
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ inputs.go-version }}
         cache: false
@@ -74,7 +74,7 @@ runs:
 
     - name: Cache Go modules
       if: ${{ (inputs.go == 'true' || inputs.enable-all == 'true') && inputs.upload-cache == 'true' }}
-      uses: useblacksmith/cache@v5
+      uses: actions/cache@v5
       with:
         path: ${{ steps.go-cache-paths.outputs.module-cache }}
         key: ${{ steps.go-cache-paths.outputs.cache-key }}
@@ -82,7 +82,7 @@ runs:
 
     - name: Restore Go modules cache (read-only)
       if: ${{ (inputs.go == 'true' || inputs.enable-all == 'true') && inputs.upload-cache != 'true' }}
-      uses: useblacksmith/cache/restore@v5
+      uses: actions/cache/restore@v5
       with:
         path: ${{ steps.go-cache-paths.outputs.module-cache }}
         key: ${{ steps.go-cache-paths.outputs.cache-key }}


### PR DESCRIPTION
## Summary

- Replace `useblacksmith/setup-go@v6`, `useblacksmith/cache@v5` and `useblacksmith/cache/restore@v5` with their official counterparts (`actions/setup-go@v6`, `actions/cache@v5`, `actions/cache/restore@v5`).

## Why

The [`useblacksmith/setup-go`](https://github.com/useblacksmith/setup-go) fork is **archived** (last push 2025-10-14) and never received the upstream fix that replaces the broken GCS fallback with `go.dev/dl`:

- Issue: https://github.com/actions/setup-go/issues/664 — _"storage.googleapis.com/golang no longer allows anonymous access causing 403 on Golang download fallback"_
- Fix (PR merged 2025-10-27): https://github.com/actions/setup-go/pull/665
- Fix is shipped in `actions/setup-go@v6.4.0` (released 2026-03-30).

This was causing intermittent CI failures in `Drafteame/api`:

```
Acquiring go1.25.0 from https://storage.googleapis.com/golang/go1.25.0.linux-amd64.tar.gz
##[error]Failed to download version 1.25.0: Error: Unexpected HTTP response: 403
```

Example failing job: https://github.com/Drafteame/api/actions/runs/26455760349/job/77892400610

## Notes

- `useblacksmith/cache` is owned by the same archived org. Swapping to `actions/cache@v5` keeps cache semantics equivalent.
- After this is merged and tagged (e.g. `v0.9.1`), consumers like `Drafteame/api` need to bump the action reference.

## Linear

ACC-1172 — https://linear.app/draftea/issue/ACC-1172

🤖 Generated with [Claude Code](https://claude.com/claude-code)